### PR TITLE
Fix code example in strings section

### DIFF
--- a/basic-clojure/strings.md
+++ b/basic-clojure/strings.md
@@ -33,7 +33,7 @@
 > **Note** Join strings together with the function str
 
 ```clojure
-(str "I" "like" "to" "be" "close" "together"
+(str "I" "like" "to" "be" "close" "together")
 (str "Hello" ", " "Devoxx UK")
 (str "Hello "  "developers" ", " "welcome" " " "to" " " "HackTheTower UK")
 ```


### PR DESCRIPTION
Parenthesis was dropped in one of the examples. If you'd like me to bundle this together with any other fixes I can wait till then.