### PR TITLE
Fix impure fn example: it was the same as the pure one.

### DIFF
--- a/thinking-functionally/impure-functions.md
+++ b/thinking-functionally/impure-functions.md
@@ -33,15 +33,15 @@ To demonstrate a side causes form of impure functions, lets create a task-comple
 ```
 (:import java.util.Date)
 
-(defn task-complete [task-name completed-date]
-  (str "Setting task " task-name " completed on " completed-date))
+(defn task-complete [task-name]
+  (str "Setting task " task-name " completed on " (java.util.Date.)))
 
-(task-complete "hack clojure" (java.util.Date.))
+(task-complete "hack clojure")
 ```
 
 > **Hint** The function `(java.util.Date.)` is actually a call to instantiate a java.util.Date object.  The fullstop character at the end of the name makes it a function call and is the short form of `(new java.util.Date)`
 
-In this example we have called to the outside world to generate a value for us.  The above example is fairly simple, however by calling the outside world rather than passing in a date it makes the functions purpose far less clear.
+In this example we have called to the outside world to generate a value for us. The above example is fairly simple, however by calling the outside world rather than passing in a date it makes the functions purpose far less clear.
 
 > **Note** Re-write the task-complete function to take both the task-name and completed-date as arguments.
 


### PR DESCRIPTION
Fix impure fn example: it was the same as the pure one.